### PR TITLE
Adds seeking to loadvid_frame_nums, and fixes a bug causing total_siz…

### DIFF
--- a/lintel/core/video_decode.h
+++ b/lintel/core/video_decode.h
@@ -194,6 +194,13 @@ decode_video_to_out_buffer(uint8_t *dest,
  * @vid_ctx: Context needed to decode frames from the video stream.
  * @num_requested_frames: Number of frames requested to fill into `dest`.
  * @frame_numbers: A list of frame numbers to extract.
+ * @should_seek: If false, decoding will be frame-accurate by starting from the
+ * first frame in the video and counting frames. However, this method may be
+ * slow.
+ * Therefore, this `should_seek` flag can be set to true to cause a seek to the
+ * closest keyframe before the first desired frame index. Note that this makes
+ * the assumption of a fixed FPS, and for variable framerate videos the
+ * approximation of average PTS duration per frame is made to do the seek.
  *
  * If there are less than `num_requested_frames` to decode from the video
  * stream, then the initial frames are looped repeatedly until the end of the
@@ -203,6 +210,7 @@ void
 decode_video_from_frame_nums(uint8_t *dest,
                              struct video_stream_context *vid_ctx,
                              int32_t num_requested_frames,
-                             const int32_t *frame_numbers);
+                             const int32_t *frame_numbers,
+                             bool should_seek);
 
 #endif // _VIDEO_DECODE_H_

--- a/lintel/py_ext/lintelmodule.c
+++ b/lintel/py_ext/lintelmodule.c
@@ -167,26 +167,30 @@ static PyObject *
 loadvid_frame_nums(PyObject *UNUSED(dummy), PyObject *args, PyObject *kw)
 {
         PyObject *result = NULL;
-        const char *video_bytes;
-        Py_ssize_t in_size_bytes;
+        const char *video_bytes = NULL;
+        Py_ssize_t in_size_bytes = 0;
         PyObject *frame_nums = NULL;
         uint32_t width = 256;
         uint32_t height = 256;
+        /* NOTE(brendan): should_seek must be int (not bool) because Python. */
+        int32_t should_seek = false;
         static char *kwlist[] = {"encoded_video",
                                  "frame_nums",
                                  "width",
                                  "height",
+                                 "should_seek",
                                  0};
 
         if (!PyArg_ParseTupleAndKeywords(args,
                                          kw,
-                                         "y#|$OII:loadvid_frame_nums",
+                                         "y#|$OIIp:loadvid_frame_nums",
                                          kwlist,
                                          &video_bytes,
                                          &in_size_bytes,
                                          &frame_nums,
                                          &width,
-                                         &height))
+                                         &height,
+                                         &should_seek))
                 return NULL;
 
         if (!PySequence_Check(frame_nums)) {
@@ -237,7 +241,8 @@ loadvid_frame_nums(PyObject *UNUSED(dummy), PyObject *args, PyObject *kw)
         decode_video_from_frame_nums((uint8_t *)(frames->ob_bytes),
                                      &vid_ctx,
                                      num_frames,
-                                     frame_nums_buf);
+                                     frame_nums_buf,
+                                     should_seek);
 
         PyMem_RawFree(frame_nums_buf);
 
@@ -254,8 +259,8 @@ static PyObject *
 loadvid(PyObject *UNUSED(dummy), PyObject *args, PyObject *kw)
 {
         PyObject *result = NULL;
-        const char *video_bytes;
-        Py_ssize_t in_size_bytes;
+        const char *video_bytes = NULL;
+        Py_ssize_t in_size_bytes = 0;
         bool should_random_seek = true;
         uint32_t width = 256;
         uint32_t height = 256;
@@ -356,7 +361,7 @@ static PyMethodDef lintel_methods[] = {
         {"loadvid_frame_nums",
          (PyCFunction)loadvid_frame_nums,
          METH_VARARGS | METH_KEYWORDS,
-         PyDoc_STR("loadvid_frame_nums(encoded_video, frame_nums, width, height) -> "
+         PyDoc_STR("loadvid_frame_nums(encoded_video, frame_nums, width, height, should_seek) -> "
                    "decoded video ByteArray object")},
         {NULL, NULL, 0, NULL}
 };

--- a/lintel/test/loadvid_test.py
+++ b/lintel/test/loadvid_test.py
@@ -55,7 +55,11 @@ def _loadvid_test_vanilla(filename, width, height):
         plt.show()
 
 
-def _loadvid_test_frame_nums(filename, width, height):
+def _loadvid_test_frame_nums(filename,
+                             width,
+                             height,
+                             start_frame,
+                             should_seek):
     """Tests loadvid_frame_nums Python extension.
 
     `loadvid_frame_nums` takes a list of (strictly increasing, and not
@@ -73,7 +77,7 @@ def _loadvid_test_frame_nums(filename, width, height):
     for _ in range(10):
         start = time.perf_counter()
 
-        i = 0
+        i = start_frame
         frame_nums = []
         for _ in range(num_frames):
             i += int(random.uniform(1, 4))
@@ -82,7 +86,8 @@ def _loadvid_test_frame_nums(filename, width, height):
         decoded_frames = lintel.loadvid_frame_nums(encoded_video,
                                                    frame_nums=frame_nums,
                                                    width=width,
-                                                   height=height)
+                                                   height=height,
+                                                   should_seek=should_seek)
         decoded_frames = np.frombuffer(decoded_frames, dtype=np.uint8)
         decoded_frames = np.reshape(decoded_frames,
                                     newshape=(num_frames, height, width, 3))
@@ -107,7 +112,21 @@ def _loadvid_test_frame_nums(filename, width, height):
               default=None,
               type=int,
               help='The _exact_ width of the input video.')
-def loadvid_test(filename, width, height):
+@click.option('--frame-nums',
+              'test_name',
+              flag_value='frame_nums',
+              default=True)
+@click.option('--loadvid',
+              'test_name',
+              flag_value='loadvid')
+@click.option('--should-seek/--no-should-seek',
+              default=False,
+              help='Whether to use the potentially frame-inaccurate seek.')
+@click.option('--start-frame',
+              default=None,
+              type=int,
+              help='Which frame to start decoding from.')
+def loadvid_test(filename, width, height, test_name, should_seek, start_frame):
     """Tests the lintel.loadvid Python extension.
 
     This program will run tests to sanity check -- visually, by using
@@ -116,5 +135,11 @@ def loadvid_test(filename, width, height):
     This program also acts as a sample use case for the APIs provided by
     Lintel.
     """
-    _loadvid_test_vanilla(filename, width, height)
-    _loadvid_test_frame_nums(filename, width, height)
+    if test_name == 'loadvid':
+        _loadvid_test_vanilla(filename, width, height)
+    elif test_name == 'frame_nums':
+        _loadvid_test_frame_nums(filename,
+                                 width,
+                                 height,
+                                 start_frame,
+                                 should_seek)

--- a/lintel/test/loadvid_test.py
+++ b/lintel/test/loadvid_test.py
@@ -123,7 +123,7 @@ def _loadvid_test_frame_nums(filename,
               default=False,
               help='Whether to use the potentially frame-inaccurate seek.')
 @click.option('--start-frame',
-              default=None,
+              default=0,
               type=int,
               help='Which frame to start decoding from.')
 def loadvid_test(filename, width, height, test_name, should_seek, start_frame):


### PR DESCRIPTION
…e_bytes to

be wrong in both ops.

Seeking in loadvid_frame_nums is only frame-accurate if the video has a fixed
frame rate, otherwise the seeking approximates the frame number by the duration
of the video (in video stream time_base units) divided by the _average_ frame
time.

Run the new test:

`lintel_test --filename <filename> --height <height> --width <width> --frame-nums --should-seek --start-frame <start-frame>`